### PR TITLE
SRE-506: SHA-pin external GitHub Actions (INC-1940)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+# SRE-506 / INC-1940: keep SHA-pinned GitHub Actions current. Every external
+# action in .github/workflows/ is pinned to a commit SHA with a "# vX" version
+# comment; Dependabot (github-actions ecosystem) bumps the SHA and the comment
+# together. A single "actions" group batches updates into one weekly PR.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/actions-pin-check.yml
+++ b/.github/workflows/actions-pin-check.yml
@@ -1,0 +1,95 @@
+---
+# SRE-506 / INC-1940: enforcement gate for SHA-pinned GitHub Actions.
+#
+# Self-contained inline check: this repo is PUBLIC and GitHub forbids public
+# repos from calling the PRIVATE reusable gate in Enflick/composite-actions, so
+# the check is inlined here. Fails the PR if any external `uses:` is not pinned
+# to a full 40-char commit SHA (docker:// to an @sha256:<digest>). First-party
+# Enflick/* and local ./ refs are exempt. The only action it uses
+# (actions/checkout) is itself pinned by SHA.
+name: Actions Pin Check
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-pinned-actions:
+    name: Verify external actions are SHA-pinned
+    runs-on: textnow
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check that every external action is pinned to a commit SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sha_re='^[0-9a-f]{40}$'
+          digest_re='^sha256:[0-9a-f]{64}$'
+          violations=0
+          scanned=0
+
+          file_list="$(
+            { find .github/workflows -maxdepth 1 -type f \
+                \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null
+              find . -path ./.git -prune -o -type f \
+                \( -name 'action.yml' -o -name 'action.yaml' \) -print 2>/dev/null
+            } | sort -u
+          )"
+
+          if [ -z "$file_list" ]; then
+            echo "No workflow or action files found to scan."
+            exit 0
+          fi
+
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            scanned=$((scanned + 1))
+            while IFS= read -r raw; do
+              lineno="${raw%%:*}"
+              content="${raw#*:}"
+              ref="${content#*uses:}"
+              ref="${ref%%#*}"
+              ref="$(printf '%s' "$ref" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+              ref="${ref%\"}"; ref="${ref#\"}"
+              ref="${ref%\'}"; ref="${ref#\'}"
+              [ -z "$ref" ] && continue
+              case "$ref" in
+                ./*) continue ;;
+                Enflick/*) continue ;;
+              esac
+              case "$ref" in
+                docker://*)
+                  digest="${ref##*@}"
+                  if [[ "$digest" =~ $digest_re ]]; then
+                    continue
+                  fi
+                  echo "::error file=$f,line=$lineno::Unpinned docker action: '$ref' (expected docker://...@sha256:<64-hex>)"
+                  violations=$((violations + 1))
+                  continue
+                  ;;
+              esac
+              if [[ "$ref" != *"@"* ]]; then
+                echo "::error file=$f,line=$lineno::Action is missing a version pin: '$ref'"
+                violations=$((violations + 1))
+                continue
+              fi
+              sha="${ref##*@}"
+              if [[ "$sha" =~ $sha_re ]]; then
+                continue
+              fi
+              echo "::error file=$f,line=$lineno::Unpinned action (pin to a 40-char commit SHA): '$ref'"
+              violations=$((violations + 1))
+            done < <(grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]' "$f" || true)
+          done < <(printf '%s\n' "$file_list")
+
+          if [ "$violations" -gt 0 ]; then
+            echo "Scanned $scanned file(s); found $violations unpinned external action(s)."
+            exit 1
+          fi
+          echo "Scanned $scanned file(s). All external actions are pinned to a commit SHA."

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,16 +28,16 @@ jobs:
       build_version: ${{ steps.prepare.outputs.build_version }}
     steps:
       - name: Pulling code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::695141026374:role/gha-runners-role
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
       - name: Install curl
         run: sudo apt-get update && sudo apt-get install -y curl


### PR DESCRIPTION
## What

Part of the org-wide GitHub Actions SHA-pinning rollout (Linear **SRE-506**, incident **INC-1940**) for `Enflick/allure-docker-service`.

- **SHA-pin every external GitHub Action** to a full 40-char commit SHA, preserving the original tag as a `# vX` comment. First-party `Enflick/*` and local `./` refs are left untouched.
- **Add `.github/dependabot.yml`** (`github-actions` ecosystem, weekly, single `actions` group) so the pinned SHAs + version comments stay current.
- **Add `.github/workflows/actions-pin-check.yml`** — an enforcement gate that fails any PR introducing an unpinned external `uses:`.

## Pinned actions (`.github/workflows/docker-publish.yml`)

| Action | Old ref | New SHA |
| --- | --- | --- |
| `actions/checkout` | `v2` | `ee0669bd1cc54295c223e0bb666b733df41de1c5` |
| `aws-actions/configure-aws-credentials` | `v4` | `7474bc4690e29a8392af63c5b98e7449536d5c3a` |
| `aws-actions/amazon-ecr-login` | `v2` | `d539f0932e70871a027e9d5a9d8fc38589180a64` |

## Why the gate is inlined

This repo is **PUBLIC**, and GitHub forbids public repos from calling the **PRIVATE** reusable gate in `Enflick/composite-actions`. The pin-check is therefore inlined as a self-contained script (its only action, `actions/checkout`, is itself SHA-pinned). The gate runs on the `textnow` runner to match this repo's existing workflow.

## Validation

- All changed/added YAML files parse cleanly.
- The gate logic was run locally against the branch: **0 violations**.

Only `uses:` ref values were changed — no workflow logic, names, or inputs were modified.

Made with [Cursor](https://cursor.com)